### PR TITLE
Merge tag 'v253' into deps/upstream_v253

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -1,0 +1,31 @@
+name: Hatchet app cleaner
+
+on:
+  schedule:
+    # Daily at 6am UTC.
+    - cron: "0 6 * * *"
+  # Allow the workflow to be manually triggered too.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hatchet-app-cleaner:
+    runs-on: ubuntu-latest
+    env:
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
+      HEROKU_DISABLE_AUTOUPDATE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Ruby and dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.1"
+      - name: Run Hatchet destroy
+        # Only apps older than 10 minutes are destroyed, to ensure that any
+        # in progress CI runs are not interrupted.
+        run: bundle exec hatchet destroy --older-than 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Main (unreleased)
 
+## v253 (2023/03/31)
+
+- Ruby versions 2.7.8, 3.0.6, 3.1.4, 3.2.2 are now available
+
+## v252 (2023/02/08)
+
+* Ruby 3.2.1 is now available
+* JRuby 9.4.1.0 is now available
+
+## v251 (2023/02/03)
+
+* Jruby 9.3.10.0 is available
+
 ## v250 (2022/12/25)
 
 * Ruby 3.2.0 is available

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby '>= 3.1', '< 3.3'
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,26 +7,26 @@ GEM
     dead_end (4.0.0)
     diff-lcs (1.5.0)
     erubis (2.7.0)
-    excon (0.94.0)
+    excon (0.99.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
       webrick
-    heroku_hatchet (7.3.4)
+    heroku_hatchet (8.0.2)
       excon (~> 0)
       platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 1)
       threaded (~> 0)
-    json (2.6.2)
+    json (2.6.3)
     moneta (1.0.0)
     multi_json (1.15.0)
     parallel (1.22.1)
     parallel_tests (4.0.0)
       parallel
-    platform-api (3.3.0)
+    platform-api (3.5.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
@@ -37,9 +37,9 @@ GEM
     redis-client (0.11.1)
       connection_pool
     rrrretry (1.0.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-retry (0.6.2)
@@ -49,7 +49,7 @@ GEM
     threaded (0.0.4)
     toml-rb (2.2.0)
       citrus (~> 3.0, > 3.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby

--- a/changelogs/v252/jruby-9-4-1-0.md
+++ b/changelogs/v252/jruby-9-4-1-0.md
@@ -1,0 +1,7 @@
+## JRuby 9.4.1.0 is now available
+
+The following Ruby versions are now available on the Heroku platform:
+
+- JRuby 9.4.1.0
+
+You can see the latest versions on the [Ruby support page](https://devcenter.heroku.com/articles/ruby-support).

--- a/changelogs/v252/ruby-3-2-1.md
+++ b/changelogs/v252/ruby-3-2-1.md
@@ -1,0 +1,7 @@
+# Ruby version 3.2.1 is now available
+
+The following Ruby versions are now available on the Heroku platform:
+
+- Ruby 3.2.1
+
+You can see the latest versions on the [Ruby support page](https://devcenter.heroku.com/articles/ruby-support).

--- a/changelogs/v253/ruby_278_306_314_322.md
+++ b/changelogs/v253/ruby_278_306_314_322.md
@@ -1,0 +1,10 @@
+## Ruby versions 2.7.8, 3.0.6, 3.1.4, 3.2.2 are now available
+
+The following Ruby versions are now available on the Heroku platform:
+
+- Ruby 2.7.8
+- Ruby 3.0.6
+- Ruby 3.1.4
+- Ruby 3.2.2
+
+You can see the latest versions on the [Ruby support page](https://devcenter.heroku.com/articles/ruby-support).

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v249"
+    BUILDPACK_VERSION = "v253"
   end
 end


### PR DESCRIPTION
Include releases of Ruby versions affected by a CVE: https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/