### PR TITLE
Fix `cp -n` warning `scalingo-24`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix `cp --update=none` warning `scalingo-24`
 
 ## [v324] - 2025-10-09
 

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -60,7 +60,7 @@ class LanguagePack::Cache
     dest ||= path
 
     case ENV["STACK"]
-    when "scalingo-20", "scalingo-22", "scalingo-24"
+    when "scalingo-20", "scalingo-22"
       copy (@cache_base + path), dest, "-a -n"
     else
       copy (@cache_base + path), dest, "-a --update=none"


### PR DESCRIPTION
Use `cp --update=none` instead of `cp -n` on `scalingo-24` builds.

`scalingo-20` and `scalingo-22` stacks should still use `cp -n`

Fix #134 