### PR TITLE
feat: add support for scalingo-26

### DIFF
--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -170,7 +170,7 @@ function checks::ensure_supported_stack() {
 
 	case "${stack}" in
 		# When removing support from a stack, move it to the bottom of the list
-		scalingo-20 | scalingo-22 | scalingo-24 | heroku-22 | heroku-24 | heroku-26)
+		scalingo-20 | scalingo-22 | scalingo-24 | scalingo-26 | heroku-22 | heroku-24 | heroku-26)
 			return 0
 			;;
 		heroku-18 | heroku-20)

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -18,7 +18,7 @@
 class LanguagePack::Helpers::DownloadPresence
   # all these stacks have identical ruby versions supported
   STACKS = ["heroku-22", "heroku-24", "heroku-26",
-            "scalingo-22", "scalingo-24"]
+            "scalingo-22", "scalingo-24", "scalingo-26"]
 
   def initialize(file_name:, arch:, amd_only_stacks:, stacks: STACKS)
     @file_name = file_name


### PR DESCRIPTION
The previous PR to add support for a stack is https://github.com/Scalingo/ruby-buildpack/pull/125. Apparently files have changed. Do you see anything I may have missed?